### PR TITLE
Update air-quality package.json

### DIFF
--- a/air-quality/package.json
+++ b/air-quality/package.json
@@ -3,6 +3,6 @@
   "version": "1.0.0",
   "dependencies": {
     "csv-parser": "1.11.0",
-    "elasticsearch": "12.1.3"
+    "elasticsearch": "^16.7.2"
   }
 }


### PR DESCRIPTION
la version version 12.X.X du package elasticsearch me déclenche un erreur lors de l'exécution d'import.js :
StatusCodeError: Content-Type header [application/x-ldjson] is not supported
Cela semble venir de la fonction bulk 
En passant à la version 16.X.X le problème disparait.
(https://discuss.elastic.co/t/node-bulk-indexing-not-working-content-type-header-application-x-ldjson-is-not-supported/114944/5)